### PR TITLE
Pceas makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ rc: realclean
 
 archive: realclean
 	@$(ECHO) "  TBZ2      `date +"%Y/%m/%d"`"
-	@$(CD) ..; $(TAR) jcf etripator-`date +"%Y%m%d"`.tar.bz2 same
+	@$(CD) ..; $(TAR) jcf $(BIN)-`date +"%Y%m%d"`.tar.bz2 same
 
 FORCE :
 ifeq (.depend,$(wildcard .depend))


### PR DESCRIPTION
By default it uses gcc and build in release mode. To build in debug mode just add "DEBUG=1" as make argument. If you want to use clang, just add "USE_CLANG=1".
So for example if you type "make USE_CLANG=1 DEBUG=1", you'll build pceas in debug with clang.
