### PR TITLE
allow '@' as local label indicator for ca65 compatibility

### DIFF
--- a/assemble.c
+++ b/assemble.c
@@ -154,8 +154,8 @@ assemble(void)
 		c = prlnbuf[i + j];
 		if (isdigit(c) && (j == 0))
 			break;
-		if (!isalnum(c) && (c != '_') && (c != '.'))
-		{ if((local_check=='.') && ((c=='-') || (c=='+')))
+		if (!isalnum(c) && (c != '_') && (c != '.') && (c != '@'))
+		{ if((local_check=='.' || local_check=='@') && ((c=='-') || (c=='+')))
             { }
           else { break;}
 		}
@@ -278,7 +278,7 @@ oplook(int *idx)
 		c = toupper(prlnbuf[*idx]);
 		if (c == ' ' || c == '\t' || c == '\0' || c == ';')
 			break;
-		if (!isalnum(c) && c != '.' && c != '*' && c != '=')
+		if (!isalnum(c) && c != '.' && c != '@' && c != '*' && c != '=')
 			return (-1);
 		if (i == 15)
 			return (-1);

--- a/expr.c
+++ b/expr.c
@@ -100,7 +100,7 @@ cont:
 
 		/* symbol */
 		else
-		if (isalpha(c) || c == '_' || c == '.') {
+		if (isalpha(c) || c == '_' || c == '.' || c == '@') {
 			if (need_operator)
 				goto error;
 			if (!push_val(T_SYMBOL))
@@ -540,7 +540,7 @@ getsym(void)
 	local_check = *expr;
     while (valid) {
         c = *expr;
-        if (isalpha(c) || c == '_' || c == '.' || (isdigit(c) && i >= 1)) {
+        if (isalpha(c) || c == '_' || c == '.' || c == '@' || (isdigit(c) && i >= 1)) {
             symbol[++i] = c;
             expr++;
         }
@@ -599,12 +599,12 @@ getsym_op(void)
 	local_check = *expr;
 	while (valid) {
 		c = *expr;
-		if (isalpha(c) || c == '_' || c == '.' || (isdigit(c) && i >= 1)) {
+		if (isalpha(c) || c == '_' || c == '.' || c == '@' || (isdigit(c) && i >= 1)) {
 			if (i < SBOLSZ - 1)
 				symbol[++i] = c;
 			expr++;
 		}
-		else if((local_check=='.') && ((c=='-') || (c=='+'))) {
+		else if((local_check=='.' || local_check=='@') && ((c=='-') || (c=='+'))) {
                 if (i < SBOLSZ - 1)
                     symbol[++i] = c;
                 expr++;

--- a/macro.c
+++ b/macro.c
@@ -405,7 +405,7 @@ macro_getargtype(char *arg)
 			c = arg[i];
 			if (isdigit(c) && (i == 0))
 				break;
-			if ((!isalnum(c)) && (c != '_') && (c != '.'))
+			if ((!isalnum(c)) && (c != '_') && (c != '.') && (c != '@'))
 				break;
 		}
 

--- a/proc.c
+++ b/proc.c
@@ -172,7 +172,7 @@ do_proc(int *ip)
 	}
 
 	/* check symbol */
-	if (symbol[1] == '.') {
+	if (symbol[1] == '.' || symbol[1] == '@') {
 		fatal_error("Proc/group name can not be local!");
 		return;
 	}

--- a/symbol.c
+++ b/symbol.c
@@ -54,8 +54,8 @@ colsym(int *ip)
 		c = prlnbuf[*ip];
 		if (isdigit(c) && (i == 0))
 			break;
-		if (!isalnum(c) && (c != '_') && (c != '.'))
-		{ if((local_check=='.') && ((c=='-') || (c=='+')))
+		if (!isalnum(c) && (c != '_') && (c != '.') && (c != '@'))
+		{ if((local_check=='.' || local_check=='@') && ((c=='-') || (c=='+')))
             { }
           else { break;}
 		}
@@ -108,7 +108,7 @@ struct t_symbol *stlook(int flag)
 	int hash;
 
 	/* local symbol */
-	if (symbol[1] == '.') {
+	if (symbol[1] == '.' || symbol[1] == '@') {
 		if (glablptr) {
 			/* search the symbol in the local list */
 			sym = glablptr->local;
@@ -300,7 +300,7 @@ labldef(int lval, int flag)
 
 		/* check if it's a local or global symbol */
 		c = lablptr->name[1];
-		if (c == '.')
+		if (c == '.' || c == '@')
 			/* local */
 			lastlabl = NULL;
 		else {


### PR DESCRIPTION
This is my first time mucking around in this codebase, so I have no real idea what I'm doing.

Due to the hackiness of this setup, local labels defined with `@` can be referenced with `.`, and vice versa. (e.g. `@loop` and `.loop` ) I don't know if that's an undesired behavior or not.